### PR TITLE
Add countries object to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,8 +14,7 @@ export interface CircleFlagProps extends DetailedHTMLProps<ImgHTMLAttributes<HTM
  */
 declare function CircleFlag(props: CircleFlagProps): JSX.Element;
 
-export { CircleFlag }
-
 declare var countries: Record<string, boolean>;
 
-export { countries };
+export { CircleFlag, countries };
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,6 @@ declare function CircleFlag(props: CircleFlagProps): JSX.Element;
 
 export { CircleFlag }
 
-declare var countries: Record<string, boolean>
+declare var countries: Record<string, boolean>;
 
 export { countries };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import { DetailedHTMLProps, ImgHTMLAttributes } from "react";
+import countryData from './src/countries'
 
 export interface CircleFlagProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
   countryCode: string;
@@ -15,3 +16,7 @@ export interface CircleFlagProps extends DetailedHTMLProps<ImgHTMLAttributes<HTM
 declare function CircleFlag(props: CircleFlagProps): JSX.Element;
 
 export { CircleFlag }
+
+const countries: Record<string, boolean> = countryData
+
+export { countries }

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,6 @@ declare function CircleFlag(props: CircleFlagProps): JSX.Element;
 
 export { CircleFlag }
 
-const countries: Record<string, boolean> = countryData
+const countries: Record<string, boolean> = countryData;
 
 export { countries }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 import { DetailedHTMLProps, ImgHTMLAttributes } from "react";
-import countryData from './src/countries'
 
 export interface CircleFlagProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
   countryCode: string;
@@ -17,6 +16,6 @@ declare function CircleFlag(props: CircleFlagProps): JSX.Element;
 
 export { CircleFlag }
 
-const countries: Record<string, boolean> = countryData;
+declare var countries: Record<string, boolean>
 
-export { countries }
+export { countries };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { DetailedHTMLProps, ImgHTMLAttributes } from "react";
 
-export interface CircleFlagProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
+interface CircleFlagProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
   countryCode: string;
 }
 
@@ -16,5 +16,5 @@ declare function CircleFlag(props: CircleFlagProps): JSX.Element;
 
 declare var countries: Record<string, boolean>;
 
-export { CircleFlag, countries };
+export { CircleFlag, CircleFlagProps, countries }
 


### PR DESCRIPTION
Hello!

I've just tried to implement this package on a TypeScript project, and noticed that the TS server is giving me an error when trying to import the `countries` object:

![image](https://user-images.githubusercontent.com/29544565/105219496-6da46880-5b4e-11eb-9997-949166e8e781.png)

I've made a tiny addition to `index.d.ts` to make sure that the object is part of the type definition, and is typed correctly.

Thanks for making this package :)